### PR TITLE
Prevent a server error if the name of the ImageField is not a valid cache-key

### DIFF
--- a/imagefield/fields.py
+++ b/imagefield/fields.py
@@ -404,7 +404,9 @@ class ImageField(models.ImageField):
         if not filename:
             return
 
-        key = "imagefield-admin-thumb:%s" % filename
+        key = (
+            "imagefield-admin-thumb:%s" % hashlib.sha256(filename.encode()).hexdigest()
+        )
         cache.delete(key)
 
         base = fieldfile._process_base(filename)

--- a/imagefield/widgets.py
+++ b/imagefield/widgets.py
@@ -5,6 +5,7 @@ import inspect
 from django import forms
 from django.core.cache import cache
 from django.utils.html import format_html
+from django.utils.text import get_valid_filename
 
 
 try:
@@ -52,11 +53,10 @@ class PreviewAndPPOIMixin(object):
         except (AttributeError, KeyError, TypeError):
             ppoi = ""
 
-        key = "imagefield-admin-thumb:%s" % value.name
+        key = "imagefield-admin-thumb:%s" % get_valid_filename(value.name)
+        url = cache.get(key, "")
 
         try:
-            url = cache.get(key, "")
-
             if not url:
                 url = value.storage.url(
                     value.process(["default", ("thumbnail", (300, 300))])
@@ -64,7 +64,7 @@ class PreviewAndPPOIMixin(object):
                 cache.set(key, url, timeout=30 * 86400)
 
         except Exception:
-            url = ""
+            pass
 
         return format_html(
             '<div class="imagefield" data-ppoi-id="{ppoi}">'

--- a/imagefield/widgets.py
+++ b/imagefield/widgets.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
 
+import hashlib
 import inspect
 
 from django import forms
 from django.core.cache import cache
 from django.utils.html import format_html
-from django.utils.text import get_valid_filename
 
 
 try:
@@ -53,7 +53,10 @@ class PreviewAndPPOIMixin(object):
         except (AttributeError, KeyError, TypeError):
             ppoi = ""
 
-        key = "imagefield-admin-thumb:%s" % get_valid_filename(value.name)
+        key = (
+            "imagefield-admin-thumb:%s"
+            % hashlib.sha256(value.name.encode()).hexdigest()
+        )
         url = cache.get(key, "")
 
         try:

--- a/imagefield/widgets.py
+++ b/imagefield/widgets.py
@@ -64,7 +64,7 @@ class PreviewAndPPOIMixin(object):
                 cache.set(key, url, timeout=30 * 86400)
 
         except Exception:
-            url = ''
+            url = ""
 
         return format_html(
             '<div class="imagefield" data-ppoi-id="{ppoi}">'

--- a/imagefield/widgets.py
+++ b/imagefield/widgets.py
@@ -53,16 +53,18 @@ class PreviewAndPPOIMixin(object):
             ppoi = ""
 
         key = "imagefield-admin-thumb:%s" % value.name
-        url = cache.get(key, "")
-        if not url:
-            try:
+
+        try:
+            url = cache.get(key, "")
+
+            if not url:
                 url = value.storage.url(
                     value.process(["default", ("thumbnail", (300, 300))])
                 )
                 cache.set(key, url, timeout=30 * 86400)
 
-            except Exception:
-                pass
+        except Exception:
+            url = ''
 
         return format_html(
             '<div class="imagefield" data-ppoi-id="{ppoi}">'


### PR DESCRIPTION
If any exception occurs while accessing the cache set the url to an empty string. If the form that contains the ImageField had any validation-errors, the name of the ImageField is not cleaned and could be an invalid key for caches like Memcached.

#3 