### PR TITLE
Stop running extended validation logic on unchanged values

### DIFF
--- a/imagefield/fields.py
+++ b/imagefield/fields.py
@@ -11,6 +11,7 @@ from django.core import checks
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
+from django.core.files.uploadedfile import UploadedFile
 from django.db import models
 from django.db.models import signals
 from django.db.models.fields import files
@@ -393,7 +394,8 @@ class ImageField(models.ImageField):
             super().save_form_data(instance, "")
             raise_validation_error(self.name, exc)
 
-        if data is not None:
+        if isinstance(data, UploadedFile):
+            # Validate newly uploaded images
             f = getattr(instance, self.name)
             if f.name:
                 image = None
@@ -407,9 +409,9 @@ class ImageField(models.ImageField):
                         image.close()
                     del image
 
-            # Reset PPOI field if image field is cleared
-            if not data and self.ppoi_field:
-                setattr(instance, self.ppoi_field, "0.5x0.5")
+        # Reset PPOI field if image field is cleared
+        if not data and self.ppoi_field:
+            setattr(instance, self.ppoi_field, "0.5x0.5")
 
     def _generate_files(self, instance, **kwargs):
         # Set by the process_imagefields management command

--- a/tests/testapp/test_imagefield.py
+++ b/tests/testapp/test_imagefield.py
@@ -17,7 +17,13 @@ from django.test.utils import isolate_apps, override_settings
 from django.urls import reverse
 from PIL import Image
 
-from imagefield.fields import IMAGEFIELDS, Context, ImageField, ImageFieldFile, _SealableAttribute
+from imagefield.fields import (
+    IMAGEFIELDS,
+    Context,
+    ImageField,
+    ImageFieldFile,
+    _SealableAttribute,
+)
 from testapp.models import (
     Model,
     ModelWithOptional,

--- a/tests/testapp/test_imagefield.py
+++ b/tests/testapp/test_imagefield.py
@@ -5,6 +5,7 @@ import re
 import sys
 import time
 from unittest import expectedFailure, skipIf
+from unittest.mock import PropertyMock, patch
 
 from django import forms
 from django.conf import settings
@@ -16,7 +17,7 @@ from django.test.utils import isolate_apps, override_settings
 from django.urls import reverse
 from PIL import Image
 
-from imagefield.fields import IMAGEFIELDS, Context, ImageField, _SealableAttribute
+from imagefield.fields import IMAGEFIELDS, Context, ImageField, ImageFieldFile, _SealableAttribute
 from testapp.models import (
     Model,
     ModelWithOptional,
@@ -246,6 +247,24 @@ class Test(BaseTest):
             m = Model(image="broken.png")
             m._skip_generate_files = True
             m.save()  # Doesn't crash
+
+    def test_no_validate_on_unchanged(self):
+        """
+        Saving a form without changing the image should not run
+        extended validation (not call _image).
+        """
+        client = self.login()
+        m = Model.objects.create(image="python-logo.png")
+
+        with patch.object(
+            ImageFieldFile, "_image", new_callable=PropertyMock
+        ) as mock_image:
+            response = client.post(
+                reverse("admin:testapp_model_change", args=(m.pk,)),
+                {"ppoi": "0.3x0.3"},
+            )
+            self.assertRedirects(response, "/admin/testapp/model/")
+            self.assertFalse(mock_image.called, "_image should not be accessed")
 
     def test_silent_failure(self):
         Model.objects.create(image="python-logo.jpg")


### PR DESCRIPTION
@matthiask So läuft es gem. meinen Tests nur noch für neue Bilder.